### PR TITLE
Update CArray.c

### DIFF
--- a/data_structures/Array/CArray.c
+++ b/data_structures/Array/CArray.c
@@ -36,12 +36,8 @@ void swap(CArray *array, int position1, int position2);
 CArray * getCArray(int size)
 {
 	CArray *array = (CArray *) malloc(sizeof(CArray));
-	array->array = (int *) malloc(sizeof(int) * size);
+	array->array = (int *) calloc(size, sizeof(int));
 	array->size = size;
-	int i;
-	for (i = 0; i < size; i++) {
-		array->array[i] = 0;
-	}
 	return array;
 }
 


### PR DESCRIPTION
Uses calloc to allocate memory which automatically assigned all bits with zero. No requirement to assigned with zero manually. 